### PR TITLE
Update ibc wasm client storage

### DIFF
--- a/spec/client/ics-008-wasm-client/README.md
+++ b/spec/client/ics-008-wasm-client/README.md
@@ -1,5 +1,5 @@
 ---
-ics: 28
+ics: 8
 title: Wasm Client
 stage: draft
 category: IBC/TAO


### PR DESCRIPTION
Per discussion: https://github.com/cosmos/ibc/pull/571#issuecomment-884872447 the light client should have the right to write its own state
